### PR TITLE
Support for URLs with query string value on IE > 9

### DIFF
--- a/javascript/src/eventsource.js
+++ b/javascript/src/eventsource.js
@@ -360,6 +360,15 @@
             }
 
             if (encodedArgs.length > 0){
+                var utilEl = document.createElement('a');
+                utilEl.href = baseURL;
+
+                if (utilEl.search && utilEl.search.length > 0) {
+                    // baseURL has already a query string; we should preserve it
+                    utilEl.search = utilEl.search + '&' + encodedArgs.join('&');
+                    return utilEl.href;
+                }
+
                 return baseURL + '?' + encodedArgs.join('&');
             }
             return baseURL;


### PR DESCRIPTION
On Internet Explorer > 9, if the URL contains some query string value the request URL will be wrong, because of a bugged edit due to `urlWithParams`, which manipulates the URL in order to add some query string values, such as `evs_buffer_size_limit`.

For example, `new EventSource '/?ciao=ola'` produces a request to `/?ciao=ola?evs_buffer_size_limit=262144`; note the double `?`, which produces the wrong query hash `ciao => ola?evs_buffer_size_limit=262144`.

This edit fixes it using the property of virtual anchor tags of parsing URLs in order to safely manipulate the URL.
