### PR TITLE
Fix for headers not being sent.

### DIFF
--- a/javascript/src/eventsource.js
+++ b/javascript/src/eventsource.js
@@ -434,7 +434,7 @@
 
             request.open('GET', evs.urlWithParams(evs.URL, evs.getArgs), true);
 
-            var headers = evs.requestHeaders; // maybe null
+            var headers = evs.xhrHeaders; // maybe null
             for (var header in headers) {
                 if (headers.hasOwnProperty(header)){
                     request.setRequestHeader(header, headers[header]);


### PR DESCRIPTION
Due to a typo, the request headers set up in `EventSource.prototype.xhrHeaders` are never being sent. I noticed this because I was not seeing the `Accept: text/event-stream` header on my server when using the polyfill.