### PR TITLE
Fixed 'console' is undefined in IE < 10

### DIFF
--- a/javascript/src/browserify-eventsource.js
+++ b/javascript/src/browserify-eventsource.js
@@ -17,7 +17,8 @@ module.exports = PolyfillEventSource;
 // Add EventSource to window if it is missing...
 if (window && !window.EventSource){
     window.EventSource = PolyfillEventSource;
-    if (console){
-	console.log("polyfill-eventsource added missing EventSource to window");
+    // Don't break IE < 10
+    if (typeof console !== "undefined" && typeof console.log !== "undefined"){
+        console.log("polyfill-eventsource added missing EventSource to window");
     }
 }


### PR DESCRIPTION
Hi! IE < 10 gets broken because browserify-eventsource.js references console variable without a proper check. Could you please update EventSource?