### PR TITLE
stop dispatching events after eventsource is closed

### DIFF
--- a/javascript/src/eventsource.js
+++ b/javascript/src/eventsource.js
@@ -274,7 +274,7 @@
                     }
                 }
 
-                if (datas.length) {
+                if (datas.length && this.readyState != this.CLOSED) {
                     // dispatch a new event
                     var event = new MessageEvent(eventType, datas.join('\n'), window.location.origin, this.lastEventId);
                     this.dispatchEvent(eventType, event);


### PR DESCRIPTION
according to the spec eventsource should only dispatch events if it is
not in the `CLOSED` state

see point 8 in this portion of the spec:
https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation

Before this fix the implementation was dispatching all events received
in a single chunk, even if the EventStream was closed while processing
one of those events.